### PR TITLE
Update JobCard to use job ID for company-related actions and data handling

### DIFF
--- a/validator-ui/src/pages/home/components/cards/JobCard.jsx
+++ b/validator-ui/src/pages/home/components/cards/JobCard.jsx
@@ -75,7 +75,10 @@ async function actionButtons(data, url, setAlertCallback, setLoading) {
  */
 export function JobCard({ data, setJobs, setAlert, setEditedData, setOpenModal }) {
     const { job_link, job_title, country, city, county, remote, edited, published, posted } = data;
-    const { company } = useParams();
+    const { id, company } = useParams();
+
+    const companyJobs = data;
+    data.companyId = id;
 
     // clear job from production
     const [clearLoading, setClearLoading] = useState(false);
@@ -101,7 +104,7 @@ export function JobCard({ data, setJobs, setAlert, setEditedData, setOpenModal }
     // sync jobs
     const [syncLoading, setSyncLoading] = useState(false);
     const syncJob = async () => {
-        await actionButtons({ company: company }, routes.JOBS_SYNC, setAlert, setSyncLoading);
+        await actionButtons({ company: id }, routes.JOBS_SYNC, setAlert, setSyncLoading);
     };
 
     // sync jobs
@@ -113,7 +116,7 @@ export function JobCard({ data, setJobs, setAlert, setEditedData, setOpenModal }
     const [deleteLoading, setDeleteLoading] = useState(false);
     const deleteJob = async () => {
         const response = await actionButtons(
-            [data],
+            [companyJobs],
             routes.JOBS_DELETE,
             setAlert,
             setDeleteLoading,
@@ -132,7 +135,7 @@ export function JobCard({ data, setJobs, setAlert, setEditedData, setOpenModal }
     const [updateLoading, setUpdateLoading] = useState(false);
     const publishJob = async () => {
         const response = await actionButtons(
-            [data],
+            [companyJobs],
             routes.JOBS_PUBLISH,
             setAlert,
             setUpdateLoading,


### PR DESCRIPTION
This pull request updates the `JobCard` component to ensure the correct company ID is passed to job-related actions and refactors how job data is handled in action callbacks. The changes improve consistency and correctness when performing actions such as syncing, deleting, and publishing jobs.

**Job action data handling:**

* The `companyId` from the URL parameters is now explicitly set on the job data object (`data.companyId = id`), ensuring all job actions reference the correct company.
* The sync job action now passes the company ID (`id`) instead of the company name to the `actionButtons` function, aligning with backend expectations.

**Refactoring job data usage in actions:**

* For delete and publish actions, the code now passes `[companyJobs]` instead of `[data]` to `actionButtons`, ensuring the job data includes the updated `companyId`. [[1]](diffhunk://#diff-62795f4fb09424039a50e3dc2b0f44d66d22e7f0ac69d8c95879d7d9d5cb2fa7L116-R119) [[2]](diffhunk://#diff-62795f4fb09424039a50e3dc2b0f44d66d22e7f0ac69d8c95879d7d9d5cb2fa7L135-R138)